### PR TITLE
fix: options for mock event

### DIFF
--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -96,14 +96,15 @@ func Example() {
 
 	so := ExampleSO{}
 	handler := orchestrator.NewEventHandler(&so, orchestrator.WithCustomLogger(logger))
-	event, _ := orchestrator.NewMockEvent(manifest, orchestrator.SenderTypeBot, orchestrator.ActionPlan)
+
+	event, _ := orchestrator.NewMockEvent(manifest, orchestrator.SenderTypeUser, orchestrator.ActionPlan, func(r *orchestrator.Request[ExampleManifest]) { r.Metadata.RequestID = "ExampleId" })
 	err := handler(context.Background(), *event)
 
 	if err != nil {
 		logger.Error().Err(err).Msg("Encountered error")
 	}
 	// Output:
-	// INF Response ready to send gorch_action=plan gorch_file_name= gorch_github_user_id=0 gorch_request_id= gorch_response={"apiVersion":"orchestrator.entur.io/response/v1","metadata":{"requestId":""},"output":"UGxhbiBhbGwgdGhlIHRoaW5ncwpDcmVhdGVkOgorIEEgdGhpbmcKVXBkYXRlZDoKISBBIHRoaW5nCkRlbGV0ZWQ6Ci0gQSB0aGluZwo=","result":"success"}
-	// ERR Could not respond error="no topic set, cannot respond" gorch_action=plan gorch_file_name= gorch_github_user_id=0 gorch_request_id=
+	// INF Response ready to send gorch_action=plan gorch_file_name= gorch_github_user_id=0 gorch_request_id=ExampleId gorch_response={"apiVersion":"orchestrator.entur.io/response/v1","metadata":{"requestId":"ExampleId"},"output":"UGxhbiBhbGwgdGhlIHRoaW5ncwpDcmVhdGVkOgorIEEgdGhpbmcKVXBkYXRlZDoKISBBIHRoaW5nCkRlbGV0ZWQ6Ci0gQSB0aGluZwo=","result":"success"}
+	// ERR Could not respond error="no topic set, cannot respond" gorch_action=plan gorch_file_name= gorch_github_user_id=0 gorch_request_id=ExampleId
 	// ERR Encountered error error="no topic set, cannot respond"
 }


### PR DESCRIPTION
Makes it possible to spoof `requestId` and other fields that wraps the incoming manifest.
Very handy for local testing and general mocking of SOs.